### PR TITLE
add insecure registry so we can use mirrored images

### DIFF
--- a/ansible/configs/ocp-workshop/files/hosts_template.3.11.272.j2
+++ b/ansible/configs/ocp-workshop/files/hosts_template.3.11.272.j2
@@ -56,6 +56,8 @@ oreg_auth_password={{ redhat_registry_password }}
 openshift_additional_registry_credentials=[{'host':'registry.connect.redhat.com','user':'{{ redhat_registry_user}}','password':'{{ redhat_registry_password }}','test_image':'mongodb/enterprise-operator:0.3.2'}]
 {% endif %}
 
+openshift_docker_insecure_registries=localhost:5000,registry-mirrored-images.apps.{{ guid }}{{ subdomain_base_suffix }}
+
 openshift_examples_modify_imagestreams=true
 
 {% if install_glusterfs|bool %}


### PR DESCRIPTION
##### SUMMARY
Add an insecure registry so the default settings in restricted-network-operator-mirror can be used without having to edit the registries.conf by hand after the cluster is up.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp-workshop

##### ADDITIONAL INFORMATION