### PR TITLE
Use awscli bundle <=1.18

### DIFF
--- a/ansible/configs/ocp4-workshop/software.yml
+++ b/ansible/configs/ocp4-workshop/software.yml
@@ -10,7 +10,7 @@
     block:
     - name: Get awscli bundle
       get_url:
-        url: https://s3.amazonaws.com/aws-cli/awscli-bundle.zip
+        url: https://s3.amazonaws.com/aws-cli/awscli-bundle-1.18.200.zip
         dest: /tmp/awscli-bundle.zip
 
     - name: Unzip awscli-bundle.zip

--- a/ansible/roles/host-ocp4-provisioner/tasks/ec2_prereqs.yml
+++ b/ansible/roles/host-ocp4-provisioner/tasks/ec2_prereqs.yml
@@ -1,7 +1,7 @@
 ---
 - name: Get awscli bundle
   get_url:
-    url: https://s3.amazonaws.com/aws-cli/awscli-bundle.zip
+    url: https://s3.amazonaws.com/aws-cli/awscli-bundle-1.18.200.zip
     dest: /tmp/awscli-bundle.zip
 
 - name: Unzip awscli-bundle.zip


### PR DESCRIPTION
Regarding, https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-python-2-7-in-aws-sdk-for-python-and-aws-cli-v1/

This may not be the best solution, but it does seem to unblock ocp4 deploy via mig-agnosticd.  I could definitely use your assistance @hhpatel14 @deepakraj1997 in confirming it also works for you too.

@pranavgaikwad , I know you have spent a lot of time with agnosticd & mig-agnosticd. I value any insight you have into a better longer-term solution if this doesn't seem appropriate.  Given mig-agnosticd's [awscli <=1.18 requirements](https://github.com/konveyor/mig-agnosticd/blob/master/requirements.txt#L2), I figured this was a good starting point.

Thanks!