### PR TITLE
Version-up to 1.5.1 switching to legacy op.  OCP3

### DIFF
--- a/ansible/roles/ocp-workload-migration/templates/operator.yml.j2
+++ b/ansible/roles/ocp-workload-migration/templates/operator.yml.j2
@@ -8,9 +8,9 @@ metadata:
     control-plane: controller-manager
     controller-tools.k8s.io: "1.0"
     openshift.io/cluster-monitoring: "true"
-  name: {{ mig_migration_namespace }}
+  name: "{{ mig_migration_namespace }}"
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   annotations:
@@ -30,7 +30,7 @@ subjects:
 userNames:
 - system:serviceaccount:{{ mig_migration_namespace }}:deployer
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   annotations:
@@ -49,7 +49,7 @@ subjects:
 userNames:
 - system:serviceaccount:{{ mig_migration_namespace }}:builder
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 groupNames:
 - system:serviceaccounts:{{ mig_migration_namespace }}
 kind: RoleBinding
@@ -72,7 +72,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: migration-operator
-  namespace: {{ mig_migration_namespace }}
+  namespace: "{{ mig_migration_namespace }}"
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -94,12 +94,12 @@ spec:
     served: true
     storage: true
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   creationTimestamp: null
   name: migration-operator
-  namespace: {{ mig_migration_namespace }}
+  namespace: "{{ mig_migration_namespace }}"
 rules:
 - apiGroups:
   - ""
@@ -145,11 +145,11 @@ rules:
   verbs:
   - '*'
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: migration-operator
-  namespace: {{ mig_migration_namespace }}
+  namespace: "{{ mig_migration_namespace }}"
 rules:
 - apiGroups:
   - ""
@@ -243,10 +243,10 @@ rules:
   - '*'
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: migration-operator
-  namespace: {{ mig_migration_namespace }}
+  namespace: "{{ mig_migration_namespace }}"
 subjects:
 - kind: ServiceAccount
   name: migration-operator
@@ -255,7 +255,7 @@ roleRef:
   name: migration-operator
   apiGroup: rbac.authorization.k8s.io
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: migration-operator
@@ -266,14 +266,14 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: migration-operator
-    namespace: {{ mig_migration_namespace }}
-namespace: {{ mig_migration_namespace }}
+    namespace: "{{ mig_migration_namespace }}"
+namespace: "{{ mig_migration_namespace }}"
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: migration-operator
-  namespace: {{ mig_migration_namespace }}
+  namespace: "{{ mig_migration_namespace }}"
   labels:
     app: migration
 spec:
@@ -288,7 +288,7 @@ spec:
       serviceAccountName: migration-operator
       containers:
       - name: operator
-        image: registry.redhat.io/rhmtc/openshift-migration-rhel7-operator:v1.5.0-24
+        image: registry.redhat.io/rhmtc/{{ mig_migration_namespace }}-legacy-rhel8-operator:v1.5.1-13
         imagePullPolicy: Always
         volumeMounts:
         - mountPath: /tmp/ansible-operator/runner
@@ -309,53 +309,53 @@ spec:
         - name: PROJECT
           value: rhmtc
         - name: RSYNC_TRANSFER_REPO
-          value: openshift-migration-rsync-transfer-rhel8
+          value: {{ mig_migration_namespace }}-rsync-transfer-rhel8
         - name: RSYNC_TRANSFER_TAG
-          value: v1.5.0-5
+          value: v1.5.1-3
         - name: HOOK_RUNNER_REPO
-          value: openshift-migration-hook-runner-rhel7
+          value: {{ mig_migration_namespace }}-hook-runner-rhel7
         - name: HOOK_RUNNER_TAG
-          value: v1.5.0-8
+          value: v1.5.1-3
         - name: MIG_CONTROLLER_REPO
-          value: openshift-migration-controller-rhel8
+          value: {{ mig_migration_namespace }}-controller-rhel8
         - name: MIG_CONTROLLER_TAG
-          value: v1.5.0-9
+          value: v1.5.1-4
         - name: MIG_UI_REPO
-          value: openshift-migration-ui-rhel8
+          value: {{ mig_migration_namespace }}-ui-rhel8
         - name: MIG_UI_TAG
-          value: v1.5.0-14
+          value: v1.5.1-4
         - name: MIG_LOG_READER_REPO
-          value: openshift-migration-log-reader-rhel8
+          value: {{ mig_migration_namespace }}-log-reader-rhel8
         - name: MIG_LOG_READER_TAG
-          value: v1.5.0-6
+          value: v1.5.1-3
         - name: MIGRATION_REGISTRY_REPO
-          value: openshift-migration-registry-rhel8
+          value: {{ mig_migration_namespace }}-registry-rhel8
         - name: MIGRATION_REGISTRY_TAG
-          value: v1.5.0-5
+          value: v1.5.1-4
         - name: VELERO_REPO
-          value: openshift-migration-velero-rhel8
+          value: {{ mig_migration_namespace }}-velero-rhel8
         - name: VELERO_TAG
-          value: v1.5.0-6
+          value: v1.5.1-4
         - name: VELERO_PLUGIN_REPO
           value: openshift-velero-plugin-rhel8
         - name: VELERO_PLUGIN_TAG
-          value: v1.5.0-5
+          value: v1.5.1-4
         - name: VELERO_RESTIC_RESTORE_HELPER_REPO
-          value: openshift-migration-velero-restic-restore-helper-rhel8
+          value: {{ mig_migration_namespace }}-velero-restic-restore-helper-rhel8
         - name: VELERO_RESTIC_RESTORE_HELPER_TAG
-          value: v1.5.0-5
+          value: v1.5.1-4
         - name: VELERO_AWS_PLUGIN_REPO
-          value: openshift-migration-velero-plugin-for-aws-rhel8
+          value: {{ mig_migration_namespace }}-velero-plugin-for-aws-rhel8
         - name: VELERO_AWS_PLUGIN_TAG
-          value: v1.5.0-4
+          value: v1.5.1-5
         - name: VELERO_GCP_PLUGIN_REPO
-          value: openshift-migration-velero-plugin-for-gcp-rhel8
+          value: {{ mig_migration_namespace }}-velero-plugin-for-gcp-rhel8
         - name: VELERO_GCP_PLUGIN_TAG
-          value: v1.5.0-4
+          value: v1.5.1-7
         - name: VELERO_AZURE_PLUGIN_REPO
-          value: openshift-migration-velero-plugin-for-microsoft-azure-rhel8
+          value: {{ mig_migration_namespace }}-velero-plugin-for-microsoft-azure-rhel8
         - name: VELERO_AZURE_PLUGIN_TAG
-          value: v1.5.0-4
+          value: v1.5.1-4
       volumes:
         - name: runner
           emptyDir: {}

--- a/ansible/roles/ocp4-workload-migration/defaults/main.yml
+++ b/ansible/roles/ocp4-workload-migration/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # workload vars
 mig_operator_release_channel: release-v1.5
-mig_operator_starting_csv: mtc-operator.v1.5.0
+mig_operator_starting_csv: mtc-operator.v1.5.1
 mig_subscription_wait: 20
 mig_expected_crds:
 - migclusters.migration.openshift.io


### PR DESCRIPTION
##### SUMMARY

Bumping up the version of operators to 1.5.1
Switched to legacy operator for versions lower than 4.6 (i.e. ocp3.11)


##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME
roles:

ocp-workload-migration 
ocp4-workload-migration 

