### PR TITLE
creation_time and stack_status changed to c_case

### DIFF
--- a/ansible/configs/ocp4-workshop/destroy_env.yml
+++ b/ansible/configs/ocp4-workshop/destroy_env.yml
@@ -26,9 +26,9 @@
         - name: Grab and set stack creation_time
           set_fact:
             stack_creation_time: >-
-              {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.creation_time }}
+              {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.CreationTime }}
             stack_status: >-
-              {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.stack_status }}
+              {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.StackStatus }}
 
         - when: stack_status == "CREATE_COMPLETE"
           block:


### PR DESCRIPTION
creation_time and stack_status changed to camel
case. Used ansible-core 2.11

##### SUMMARY

Error:
The error was: 'dict object' has no attribute 'creation_time'\n\nThe error appears to be in '/home/whayutin/OPENSHIFT/git/AGNOSTICD/konveyor/agnosticd/ansible/configs/ocp4-workshop/destroy_env.yml'

Facts:
ok: [localhost] => {
    "stack_facts": {
        "ansible_facts": {
            "cloudformation": {
                "ocp4-workshop-wdh0827ocp4a": {
                    "stack_description": {
                        "Capabilities": [
                            "CAPABILITY_IAM",
                            "CAPABILITY_NAMED_IAM"
                        ],
                        "CreationTime": "2021-08-27T17:09:26.845000+00:00",
<snip>
"StackStatus": "CREATE_COMPLETE",


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

configs/ocp4-workshop/destroy_env

##### ADDITIONAL INFORMATION

ansible [core 2.11.4] 
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/whayutin/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/whayutin/OPENSHIFT/virtenv_agnosticd_mig/lib64/python3.9/site-packages/ansible
  ansible collection location = /home/whayutin/.ansible/collections:/usr/share/ansible/collections
  executable location = /home/whayutin/OPENSHIFT/virtenv_agnosticd_mig/bin/ansible
  python version = 3.9.6 (default, Jul 16 2021, 00:00:00) [GCC 10.3.1 20210422 (Red Hat 10.3.1-1)]
  jinja version = 3.0.1
  libyaml = True

```
ansible==4.4.0
ansible-core==2.11.4
awscli==1.20.24
boto==2.49.0
boto3==1.18.24
botocore==1.21.24
cffi==1.14.6
colorama==0.4.3
cryptography==3.4.7
docutils==0.15.2
Jinja2==3.0.1
jmespath==0.10.0
MarkupSafe==2.0.1
packaging==21.0
pyasn1==0.4.8
pycparser==2.20
pyparsing==2.4.7
python-dateutil==2.8.2
PyYAML==5.4.1
resolvelib==0.5.4
rsa==4.7.2
s3transfer==0.5.0
six==1.16.0
urllib3==1.26.6


```
