### PR TITLE
OADP default loc of lab-instructions dir

### DIFF
--- a/ansible/roles/ocp4-workload-oadp/defaults/main.yml
+++ b/ansible/roles/ocp4-workload-oadp/defaults/main.yml
@@ -49,7 +49,7 @@ oadp_expected_crds:
 
 # Bookbag Lab Variables
 bookbag_repo: "https://github.com/kaovilai/labs.git"
-bookbag_dir: "/home/{{ ansible_user }}/lab-instructions"
+bookbag_dir: "/home/{{ student_user }}/lab-instructions"
 bookbag_build_dir: "oadp/bookbag"
 
 pre_deploy_sample_apps:


### PR DESCRIPTION

##### SUMMARY

The lab-instructions for OADP should be in a user dir, not ec2 user. 

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

role: ocp4-workload-oadp

##### ADDITIONAL INFORMATION